### PR TITLE
Use cp instead of rsync

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           --exclude 'release.tar.gz' \
           -zcvf release.tar.gz .
       - name: Upload assets
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release.tar.gz
           path: release.tar.gz

--- a/install.sh
+++ b/install.sh
@@ -24,13 +24,16 @@ fi
   cd "$(dirname "$0")"
   mkdir -pv ~/.config/vim/
   echo "copy $(pwd)/ to ~/.config/vim/"
-  rsync -a \
-    --exclude ".gitignore" \
-    --exclude ".gitmodules" \
-    --exclude ".git" \
-    --exclude ".github" \
-    --exclude "dev-tool" \
-    ./ ~/.config/vim/
+  echo "-------"
+  find . -maxdepth 1 -mindepth 1 \
+    -not -path "./.gitignore" \
+    -not -path "./.gitmodules" \
+    -not -path "./.git" \
+    -not -path "./.github" \
+    -not -path "./dev-tool" \
+    -exec cp -rp {} ~/.config/vim/ \; \
+    -print
+  echo "-------"
 )
 
 mkdir -pv ~/.config/vim/tmp/


### PR DESCRIPTION
- rsyncの代わりにcpを使うようにした。rsyncコマンドのない環境でも動作するようにした。
- Github actionsにて、`actions/upload-artifact`の@3が使えなくなったため@4を使うようにした
  - [Deprecation notice: v3 of the artifact actions - GitHub Changelog](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
